### PR TITLE
Fix TypeError in `ui.table` instantiation by switching to keyword arguments

### DIFF
--- a/panel/ui/pages/clients_page.py
+++ b/panel/ui/pages/clients_page.py
@@ -81,13 +81,11 @@ async def clients_page_stuff(db_path: str) -> None:
     with ui.card().classes(
         "w-full h-full justify-center no-shadow border-[1px] border-gray-200 rounded-lg"
     ):
-        with ui.table(
-            columns,
-            rows=data,
-            pagination=10,
-            selection="single",
-            title="Clients Page",
-        ).classes("h-full w-full bordered") as table:
+        # fixed the TypeError by passing arguments to the ui.table() using keyword arguments.
+        # previous version passed arguments positionally, which caused a mismatch with the expected constructor
+        # of the Table class, resulting in the error: "Table.__init__() takes 1 positional argument but 2 were given."
+        # now, columns, rows, pagination, selection, and title are passed as keyword arguments, resolving the issue :)
+        with ui.table(columns=columns, rows=data, pagination=10, selection="single", title="Clients Page").classes("h-full w-full bordered") as table:
             with table.add_slot("top-right"):
                 with ui.input(placeholder="Search").props("type=search").bind_value(
                     table, "filter"


### PR DESCRIPTION
### Description:  
This pull request fixes a `TypeError` encountered when instantiating the `ui.table` object on the clients page. The error message was:  
`TypeError: Table.__init__() takes 1 positional argument but 2 positional arguments (and 4 keyword-only arguments) were given.`

The issue occurred because the `ui.table` function was being called with positional arguments instead of the required keyword arguments, leading to a mismatch in the function signature.

### Changes made:
- Updated the instantiation of `ui.table` by switching to **keyword arguments** for `columns`, `rows`, `pagination`, `selection`, and `title` parameters.
  
### Before:
```python
with ui.table(
    columns,
    rows=data,
    pagination=10,
    selection="single",
    title="Clients Page",
).classes("h-full w-full bordered") as table:
```

### After:
```python
with ui.table(columns=columns, rows=data, pagination=10, selection="single", title="Clients Page").classes("h-full w-full bordered") as table:
```

### Issue fixed:
- **TypeError**: This fixes the error caused by improper argument handling, allowing the page to render correctly with the data table.

### Testing:
- The code has been tested locally, and the clients page now correctly displays the data table without errors.